### PR TITLE
fix: Resolve Ruby version conflicts and GitHub Pages compatibility

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.0'
           bundler-cache: true
 
       - name: Setup Pages
@@ -42,7 +42,7 @@ jobs:
         run: bundle install
 
       - name: Build with Jekyll
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,9 @@
 source "https://rubygems.org"
 
-# Jekyll and GitHub Pages
-gem "jekyll", "~> 4.3.0"
+# Use GitHub Pages gem which includes Jekyll and compatible plugins
 gem "github-pages", group: :jekyll_plugins
 
-# Plugins
+# Additional plugins (these are included in github-pages but listed for clarity)
 group :jekyll_plugins do
   gem "jekyll-feed"
   gem "jekyll-sitemap"

--- a/_config.yml
+++ b/_config.yml
@@ -7,9 +7,8 @@ url: "https://nishanth.reddy.github.io" # Change this to your GitHub username
 # Build settings
 markdown: kramdown
 highlighter: rouge
-theme: minima
 
-# Plugins
+# Plugins (these are automatically included with github-pages gem)
 plugins:
   - jekyll-feed
   - jekyll-sitemap
@@ -49,6 +48,10 @@ exclude:
   - vendor/gems/
   - vendor/ruby/
   - "*.pdf"
+  - _plugins
+  - _scripts
+  - PR_INSTRUCTIONS.md
+  - JEKYLL_SETUP.md
 
 # Include files that start with underscore
 include:


### PR DESCRIPTION
- Remove Jekyll version constraint that conflicts with github-pages gem
- Use github-pages gem which includes compatible Jekyll version
- Update Ruby version to 3.0 for better compatibility
- Simplify Jekyll build command
- Exclude plugin files from processing since GitHub Pages has restrictions
- This should resolve the bundler dependency conflicts